### PR TITLE
implement test for collecting arbitrary value with a beforeStatement hook

### DIFF
--- a/src/Insight/IGTest.class.st
+++ b/src/Insight/IGTest.class.st
@@ -81,6 +81,24 @@ IGTest >> testCollectArbitraryValueWithAnBeforeAndAfterStatementHook [
 ]
 
 { #category : 'method tests' }
+IGTest >> testCollectArbitraryValueWithAnBeforeStatementHook [
+
+	| instrumentation beforeHook collector methodToInstrument |
+
+	collector := IGCollector collect: [ :ctx | ctx variableNamed: 't' ].
+	beforeHook := IGBeforeStatementHook new do: collector.
+
+	instrumentation := IGInstrumentation new addHook: beforeHook.
+	methodToInstrument := IGTest >> #conditionalMethod:.
+
+	instrumentation instrumentMethod: methodToInstrument
+		during: [ self conditionalMethod: false ].
+
+	self assertCollection: collector collection asArray
+		equals: { nil. nil. 2 }
+]
+
+{ #category : 'method tests' }
 IGTest >> testCollectStatementResultsWithAnAfterStatementHook [
 	
 	| instrumentation afterHook collector methodToInstrument |


### PR DESCRIPTION
# Notice
This PR test was changed as the old idea was moved into its own issue.
Previous idea:
> This PR add a failing test where if the halt exception is handled, the beforeHook do not correclty add a self instance to the colletor.

> this test is actually testing that when putting a before statement hook with a break (Halt), the statement should not be executed.

## New content
Simple test using a `beforeStatementHook` on a branching method.

Closes #21