### PR TITLE
add a test with two `afterStatementHook`

### DIFF
--- a/src/Insight/IGTest.class.st
+++ b/src/Insight/IGTest.class.st
@@ -10,10 +10,11 @@ Class {
 IGTest >> conditionalMethod: aBoolean [
 
 	| t |
-	
-	aBoolean ifTrue: [ t := 1 ] ifFalse: [ t := 2 ].
-	
-	^ t
+
+	aBoolean ifTrue: [ t := 1 ]
+		ifFalse: [ t := 2 ].
+
+	^t
 ]
 
 { #category : 'helper methods' }
@@ -24,7 +25,7 @@ IGTest >> emptyMethod [
 IGTest >> incrementingTvariable [
 
 	| t |
-	
+
 	t := 0.
 
 	t := t + 1
@@ -40,58 +41,58 @@ IGTest >> returnMethod [
 IGTest >> sequencialMethod [
 
 	1 + 2.
-	
+
 	3 + 4.
-	
+
 	self yourself
 ]
 
 { #category : 'method tests' }
 IGTest >> testCollectArbitraryValueWithAnAfterStatementHook [
-	
+
 	| instrumentation afterHook collector result methodToInstrument |
-	
+
 	collector := IGCollector collect: [ :instrumentationContext | instrumentationContext receiver ].
 	afterHook := IGAfterStatementHook new do: collector.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #sequencialMethod.
-	
+
 	result := instrumentation instrumentMethod: methodToInstrument during: [ self sequencialMethod ].
-	
+
 	self assert: (collector includes: self)
 ]
 
 { #category : 'method tests' }
 IGTest >> testCollectArbitraryValueWithAnBeforeAndAfterStatementHook [
-	
+
 	| instrumentation beforeHook afterHook beforeCollector afterCollector result methodToInstrument |
-	
+
 	beforeCollector := IGCollector collect: [ :instrumentationContext | instrumentationContext variableNamed: 't' ].
 	afterCollector := IGCollector collect: [ :instrumentationContext | instrumentationContext variableNamed: 't' ].
-	
+
 	beforeHook := IGBeforeStatementHook new do: beforeCollector.
 	afterHook := IGAfterStatementHook new do: afterCollector.
 	instrumentation := IGInstrumentation new addHook: afterHook; addHook: beforeHook.
 	methodToInstrument := IGTest >> #incrementingTvariable.
 
 	result := instrumentation instrumentMethod: methodToInstrument during: [ self incrementingTvariable ].
-	
+
 	self assert: beforeCollector collection asArray equals: { nil . 0 }.
 	self assert: afterCollector collection asArray equals: { 0 . 1 }
 ]
 
 { #category : 'method tests' }
 IGTest >> testCollectStatementResultsWithAnAfterStatementHook [
-	
+
 	| instrumentation afterHook collector methodToInstrument |
-	
+
 	collector := IGCollector collect: [ :instrumentationContext | instrumentationContext statementResult ].
 	afterHook := IGAfterStatementHook new do: collector.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #sequencialMethod.
-	
+
 	instrumentation instrumentMethod: methodToInstrument during: [ self sequencialMethod ].
-	
+
 	self assertCollection: collector collection asArray equals: { 3 . 7 . self }
 ]
 
@@ -99,16 +100,16 @@ IGTest >> testCollectStatementResultsWithAnAfterStatementHook [
 IGTest >> testCountAllAssignmentsCallingOnlyOneAssignmentInAClass [
 
 	| instrumentation afterHook counter |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterAssignmentHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
-	
+
 	instrumentation instrumentClass: IGMock during: [ | instance |
 		instance := IGMock basicNew.
 		instance variable2: 'hola'.
 	].
-	
+
 	self assert: (counter count) equals: 1
 ]
 
@@ -116,64 +117,64 @@ IGTest >> testCountAllAssignmentsCallingOnlyOneAssignmentInAClass [
 IGTest >> testCountAllAssignmentsInAClass [
 
 	| instrumentation afterHook counter |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterAssignmentHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
-	
+
 	instrumentation instrumentClass: IGMock during: [ | instance |
 		instance := IGMock new.
 		instance variable1: 42.
 		instance variable2: 'hola'.
 	].
-	
+
 	self assert: (counter count) equals: 5
 ]
 
 { #category : 'class tests' }
 IGTest >> testCountAllStatementExecutionsInAClass [
-	
+
 	| instrumentation afterHook counter |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterStatementHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
-	
+
 	instrumentation instrumentClass: IGMock during: [ | instance |
 		instance := IGMock new.
 		instance variable1: 42.
 		instance variable2: 'hola'.
 	].
-	
+
 	self assert: (counter count) equals: 5
 ]
 
 { #category : 'method tests' }
 IGTest >> testCounterPerStatement [
-	
+
 	| instrumentation afterHook counter result methodToInstrument |
-	
+
 	counter := IGCounter new countKeyBy: [ :context | context astNode ].
 	afterHook := IGAfterStatementHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #incrementingTvariable.
-	
+
 	methodToInstrument ast statements do: [ :node |
-		self assert: (counter countAt: node) equals: 0		
+		self assert: (counter countAt: node) equals: 0
 	].
 
 	result := instrumentation instrumentMethod: methodToInstrument during: [ self incrementingTvariable ].
-	
+
 	methodToInstrument ast statements do: [ :node |
-		self assert: (counter countAt: node) equals: 1		
+		self assert: (counter countAt: node) equals: 1
 	].
 ]
 
 { #category : 'method tests' }
 IGTest >> testCounterWithAnAfterStatementHook [
-	
+
 	| instrumentation afterHook counter result methodToInstrument |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterStatementHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
@@ -182,20 +183,20 @@ IGTest >> testCounterWithAnAfterStatementHook [
 	self assert: counter count equals: 0.
 
 	result := instrumentation instrumentMethod: methodToInstrument during: [ self incrementingTvariable ].
-	
+
 	self assert: counter count equals: 2.
 ]
 
 { #category : 'method tests' }
 IGTest >> testCoverageInstrumentAConditionalWithAnAfterHook [
-	
+
 	| instrumentation afterHook collector methodToInstrument ifStatement trueStatement falseStatement |
-	
+
 	collector := IGCounter new countKeyBy: [ :context | context astNode ].
 	afterHook := IGAfterStatementHook new do: collector.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #conditionalMethod:.
-	
+
 	instrumentation instrumentMethod: methodToInstrument during: [
 		self conditionalMethod: true.
 		self conditionalMethod: false
@@ -204,7 +205,7 @@ IGTest >> testCoverageInstrumentAConditionalWithAnAfterHook [
 	ifStatement := methodToInstrument ast statements first.
 	trueStatement := ifStatement arguments first statements first.
 	falseStatement := ifStatement arguments second statements first.
-	
+
 	self assert: (collector countAt: ifStatement) equals: 2.
 	self assert: (collector countAt: trueStatement) equals: 1.
 	self assert: (collector countAt: falseStatement) equals: 1.
@@ -212,16 +213,16 @@ IGTest >> testCoverageInstrumentAConditionalWithAnAfterHook [
 
 { #category : 'method tests' }
 IGTest >> testCoverageInstrumentAStatementWithAnAfterHook [
-	
+
 	| instrumentation afterHook collector result methodToInstrument |
-	
+
 	collector := IGCollector new.
 	afterHook := IGAfterStatementHook new do: collector.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #sequencialMethod.
-	
+
 	result := instrumentation instrumentMethod: methodToInstrument during: [ self sequencialMethod ].
-	
+
 	methodToInstrument ast statements do: [ :statement |
 		self assert: (collector includes: statement)
 	]
@@ -231,45 +232,44 @@ IGTest >> testCoverageInstrumentAStatementWithAnAfterHook [
 IGTest >> testEmptyMethod [
 
 	| instrumentation afterHook counter methodToInstrument |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterStatementHook new do: counter.
 
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #emptyMethod.
-	
-	instrumentation instrumentMethod: methodToInstrument during: [ self emptyMethod ].
-	
-	self assert: counter count equals: 0
 
+	instrumentation instrumentMethod: methodToInstrument during: [ self emptyMethod ].
+
+	self assert: counter count equals: 0
 ]
 
 { #category : 'method tests' }
 IGTest >> testInstrumentAfterReturn [
-	
+
 	| instrumentation afterHook counter methodToInstrument |
-	
+
 	counter := IGCounter new.
 	afterHook := IGAfterStatementHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: afterHook.
 	methodToInstrument := IGTest >> #returnMethod.
-	
+
 	instrumentation instrumentMethod: methodToInstrument during: [ self returnMethod ].
-	
+
 	self assert: counter count equals: 1
 ]
 
 { #category : 'method tests' }
 IGTest >> testInstrumentBeforeReturn [
-	
+
 	| instrumentation beforeHook counter methodToInstrument |
-	
+
 	counter := IGCounter new.
 	beforeHook := IGBeforeStatementHook new do: counter.
 	instrumentation := IGInstrumentation new addHook: beforeHook.
 	methodToInstrument := IGTest >> #returnMethod.
-	
+
 	instrumentation instrumentMethod: methodToInstrument during: [ self returnMethod ].
-	
+
 	self assert: counter count equals: 1
 ]

--- a/src/Insight/IGTest.class.st
+++ b/src/Insight/IGTest.class.st
@@ -150,6 +150,29 @@ IGTest >> testCountAllStatementExecutionsInAClass [
 ]
 
 { #category : 'method tests' }
+IGTest >> testCountStatementsAndVariableValueWith2AfterHooks [
+
+	| instrumentation afterCounterHook counter afterCollectorHook collector methodToInstrument |
+
+	counter := IGCounter new.
+	afterCounterHook := IGAfterStatementHook new do: counter.
+
+	collector := IGCollector collect: [ :ctx | ctx variableNamed: 't' ].
+	afterCollectorHook := IGAfterStatementHook new do: collector.
+
+	instrumentation := IGInstrumentation new
+								addHook: afterCounterHook;
+								addHook: afterCollectorHook.
+	methodToInstrument := IGTest >> #conditionalMethod:.
+
+	instrumentation instrumentMethod: methodToInstrument
+		during: [ self conditionalMethod: true ].
+
+	self assert: counter count equals: 3.
+	self assertCollection: collector collection asArray equals: { 1. 1. 1 }
+]
+
+{ #category : 'method tests' }
 IGTest >> testCounterPerStatement [
 
 	| instrumentation afterHook counter result methodToInstrument |


### PR DESCRIPTION
This PR contain a single test that both count the numbers of statement executed and track the value of the varaible `t` throughout.
As a reminder the number of statement in the `conditionalMethod` is 3:
```SmallTalk
"In either case this count as 2 statements:
The one inside the conditional blocks and the ifTrue:ifFalse: message statement"
aBoolean ifTrue: [] ifFalse: [].

^ t
```

You can skip reviewving the first commit of this PR (**fix some linter and formatting issue**) as it only removed extra whitespaces inside empty lines.

You should review directly the [**add a test for same hook compatibility**](https://github.com/FedeLoch/insight/commit/11f35a22e20acbb32cd4490a295ee703cdfaa9e8) commit.

Closes #23
