### PR TITLE
Implementing Call Graph Profiler

### DIFF
--- a/src/BaselineOfInsight/BaselineOfInsight.class.st
+++ b/src/BaselineOfInsight/BaselineOfInsight.class.st
@@ -10,7 +10,7 @@ BaselineOfInsight >> baseline: spec [
 
 	<baseline>
 	
-	spec baseline: 'IllimaniProfiler' with: [ spec repository: 'github://jordanmontt/illimani-memory-profiler:main' ].
+	spec baseline: 'MethodCallGraph' with: [ spec repository: 'github://jordanmontt/MethodCallGraph:main' ].
 	
-	spec package: 'Insight' with: [ spec requires: #( 'IllimaniProfiler' ) ]
+	spec package: 'Insight' with: [ spec requires: #( 'MethodCallGraph' ) ]
 ]

--- a/src/BaselineOfInsight/BaselineOfInsight.class.st
+++ b/src/BaselineOfInsight/BaselineOfInsight.class.st
@@ -1,6 +1,7 @@
 Class {
 	#name : 'BaselineOfInsight',
 	#superclass : 'BaselineOf',
+	#category : 'BaselineOfInsight',
 	#package : 'BaselineOfInsight'
 }
 
@@ -8,5 +9,8 @@ Class {
 BaselineOfInsight >> baseline: spec [
 
 	<baseline>
-	spec for: #common do: [ spec package: #Insight ]
+	
+	spec baseline: 'IllimaniProfiler' with: [ spec repository: 'github://jordanmontt/illimani-memory-profiler:main' ].
+	
+	spec package: 'Insight' with: [ spec requires: #( 'IllimaniProfiler' ) ]
 ]

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -6,14 +6,8 @@ Class {
 	#tag : 'Call Graph'
 }
 
-{ #category : 'accessing' }
-AfterHistoryAction class >> history: history [
-
-	^ self new history: history
-]
-
 { #category : 'as yet unclassified' }
-AfterHistoryAction >> do: method [
+AfterHistoryAction >> do: methodNode [
 	
-	history pop: method
+	history pop: (methodNode propertyAt: 'compiledMethod')
 ]

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -1,7 +1,22 @@
 Class {
 	#name : 'AfterHistoryAction',
-	#superclass : 'Object',
+	#superclass : 'IGDoAction',
+	#instVars : [
+		'history'
+	],
 	#category : 'Insight-Call Graph',
 	#package : 'Insight',
 	#tag : 'Call Graph'
 }
+
+{ #category : 'accessing' }
+AfterHistoryAction class >> history: history [
+
+	^ self new history: history
+]
+
+{ #category : 'accessing' }
+AfterHistoryAction >> history: aHistory [
+
+	history := aHistory 
+]

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -15,8 +15,20 @@ AfterHistoryAction class >> history: history [
 	^ self new history: history
 ]
 
+{ #category : 'as yet unclassified' }
+AfterHistoryAction >> do: value [
+	
+	1 halt.
+]
+
 { #category : 'accessing' }
 AfterHistoryAction >> history: aHistory [
 
 	history := aHistory 
+]
+
+{ #category : 'as yet unclassified' }
+AfterHistoryAction >> reificationForContext: context [
+
+	^ context astNode
 ]

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -16,9 +16,9 @@ AfterHistoryAction class >> history: history [
 ]
 
 { #category : 'as yet unclassified' }
-AfterHistoryAction >> do: value [
+AfterHistoryAction >> do: method [
 	
-	1 halt.
+	history pop: method
 ]
 
 { #category : 'accessing' }

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'AfterHistoryAction',
-	#superclass : 'IGDoAction',
-	#instVars : [
-		'history'
-	],
+	#superclass : 'CallGraphHistoryAction',
 	#category : 'Insight-Call Graph',
 	#package : 'Insight',
 	#tag : 'Call Graph'
@@ -19,16 +16,4 @@ AfterHistoryAction class >> history: history [
 AfterHistoryAction >> do: method [
 	
 	history pop: method
-]
-
-{ #category : 'accessing' }
-AfterHistoryAction >> history: aHistory [
-
-	history := aHistory 
-]
-
-{ #category : 'as yet unclassified' }
-AfterHistoryAction >> reificationForContext: context [
-
-	^ context astNode
 ]

--- a/src/Insight/AfterHistoryAction.class.st
+++ b/src/Insight/AfterHistoryAction.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'AfterHistoryAction',
+	#superclass : 'Object',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}

--- a/src/Insight/AllocationGraph.extension.st
+++ b/src/Insight/AllocationGraph.extension.st
@@ -3,5 +3,14 @@ Extension { #name : 'AllocationGraph' }
 { #category : '*Insight' }
 AllocationGraph class >> from: aHistory [
 
-	^ self new
+	^ aHistory actions inject: self new into: [ :graph :action |
+		"TODO: create the graph using the actions, we consume the stack actions and create new edges from them"
+		"Example:
+		#('push' #initialize) [ first ]
+		#('pop' #initialize)
+		#('push' #messageA:)
+		#('push' #messageB:)
+		#('pop' #messageA:) [ last ]"
+		1 halt.
+	]
 ]

--- a/src/Insight/AllocationGraph.extension.st
+++ b/src/Insight/AllocationGraph.extension.st
@@ -1,27 +1,6 @@
 Extension { #name : 'AllocationGraph' }
 
 { #category : '*Insight' }
-AllocationGraph >> buildFrom: aHistory [
-
-	| callStack |
-	
-	callStack := Stack new.
-
-	aHistory actions do: [ :action |
-		action isPush ifTrue: [ callStack push: action method ]
-			ifFalse: [ | caller callee edge |
-				callee := action method.
-				callStack isEmpty ifTrue: [ "root node, no action" ] ifFalse: [
-					caller := callStack pop.
-					edge := self edgeFrom: caller to: callee. "We are creating the edge here"
-				]
-			]
-		].
-
-	^ self
-]
-
-{ #category : '*Insight' }
 AllocationGraph class >> from: aHistory [
 
 	^ self new buildFrom: aHistory

--- a/src/Insight/AllocationGraph.extension.st
+++ b/src/Insight/AllocationGraph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'AllocationGraph' }
+
+{ #category : '*Insight' }
+AllocationGraph class >> from: aHistory [
+
+	^ self new
+]

--- a/src/Insight/AllocationGraph.extension.st
+++ b/src/Insight/AllocationGraph.extension.st
@@ -3,14 +3,5 @@ Extension { #name : 'AllocationGraph' }
 { #category : '*Insight' }
 AllocationGraph class >> from: aHistory [
 
-	^ aHistory actions inject: self new into: [ :graph :action |
-		"TODO: create the graph using the actions, we consume the stack actions and create new edges from them"
-		"Example:
-		#('push' #initialize) [ first ]
-		#('pop' #initialize)
-		#('push' #messageA:)
-		#('push' #messageB:)
-		#('pop' #messageA:) [ last ]"
-		1 halt.
-	]
+	^ self new buildFrom: aHistory
 ]

--- a/src/Insight/AllocationGraph.extension.st
+++ b/src/Insight/AllocationGraph.extension.st
@@ -1,6 +1,27 @@
 Extension { #name : 'AllocationGraph' }
 
 { #category : '*Insight' }
+AllocationGraph >> buildFrom: aHistory [
+
+	| callStack |
+	
+	callStack := Stack new.
+
+	aHistory actions do: [ :action |
+		action isPush ifTrue: [ callStack push: action method ]
+			ifFalse: [ | caller callee edge |
+				callee := action method.
+				callStack isEmpty ifTrue: [ "root node, no action" ] ifFalse: [
+					caller := callStack pop.
+					edge := self edgeFrom: caller to: callee. "We are creating the edge here"
+				]
+			]
+		].
+
+	^ self
+]
+
+{ #category : '*Insight' }
 AllocationGraph class >> from: aHistory [
 
 	^ self new buildFrom: aHistory

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'BeforeHistoryAction',
-	#superclass : 'IGDoAction',
-	#instVars : [
-		'history'
-	],
+	#superclass : 'CallGraphHistoryAction',
 	#category : 'Insight-Call Graph',
 	#package : 'Insight',
 	#tag : 'Call Graph'
@@ -19,16 +16,4 @@ BeforeHistoryAction class >> history: history [
 BeforeHistoryAction >> do: value [
 	
 	history push: value
-]
-
-{ #category : 'accessing' }
-BeforeHistoryAction >> history: aHistory [
-
-	history := aHistory
-]
-
-{ #category : 'as yet unclassified' }
-BeforeHistoryAction >> reificationForContext: context [
-
-	^ context astNode
 ]

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -1,7 +1,22 @@
 Class {
 	#name : 'BeforeHistoryAction',
-	#superclass : 'Object',
+	#superclass : 'IGDoAction',
+	#instVars : [
+		'history'
+	],
 	#category : 'Insight-Call Graph',
 	#package : 'Insight',
 	#tag : 'Call Graph'
 }
+
+{ #category : 'accessing' }
+BeforeHistoryAction class >> history: history [
+
+	^ self new history: history
+]
+
+{ #category : 'accessing' }
+BeforeHistoryAction >> history: aHistory [
+
+	history := aHistory
+]

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -15,8 +15,20 @@ BeforeHistoryAction class >> history: history [
 	^ self new history: history
 ]
 
+{ #category : 'as yet unclassified' }
+BeforeHistoryAction >> do: value [
+	
+	1 halt.
+]
+
 { #category : 'accessing' }
 BeforeHistoryAction >> history: aHistory [
 
 	history := aHistory
+]
+
+{ #category : 'as yet unclassified' }
+BeforeHistoryAction >> reificationForContext: context [
+
+	^ context astNode
 ]

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -18,7 +18,7 @@ BeforeHistoryAction class >> history: history [
 { #category : 'as yet unclassified' }
 BeforeHistoryAction >> do: value [
 	
-	1 halt.
+	history push: value
 ]
 
 { #category : 'accessing' }

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'BeforeHistoryAction',
+	#superclass : 'Object',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}

--- a/src/Insight/BeforeHistoryAction.class.st
+++ b/src/Insight/BeforeHistoryAction.class.st
@@ -6,14 +6,8 @@ Class {
 	#tag : 'Call Graph'
 }
 
-{ #category : 'accessing' }
-BeforeHistoryAction class >> history: history [
-
-	^ self new history: history
-]
-
 { #category : 'as yet unclassified' }
-BeforeHistoryAction >> do: value [
-	
-	history push: value
+BeforeHistoryAction >> do: methodNode [
+
+	history push: (methodNode propertyAt: 'compiledMethod')
 ]

--- a/src/Insight/CallGraphHistoryAction.class.st
+++ b/src/Insight/CallGraphHistoryAction.class.st
@@ -10,6 +10,12 @@ Class {
 }
 
 { #category : 'accessing' }
+CallGraphHistoryAction class >> history: history [
+
+	^ self new history: history
+]
+
+{ #category : 'accessing' }
 CallGraphHistoryAction >> history: aHistory [
 
 	history := aHistory
@@ -18,5 +24,5 @@ CallGraphHistoryAction >> history: aHistory [
 { #category : 'as yet unclassified' }
 CallGraphHistoryAction >> reificationForContext: context [
 
-	^ context astNode
+	^ context astNode 
 ]

--- a/src/Insight/CallGraphHistoryAction.class.st
+++ b/src/Insight/CallGraphHistoryAction.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : 'CallGraphHistoryAction',
+	#superclass : 'IGDoAction',
+	#instVars : [
+		'history'
+	],
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'accessing' }
+CallGraphHistoryAction >> history: aHistory [
+
+	history := aHistory
+]
+
+{ #category : 'as yet unclassified' }
+CallGraphHistoryAction >> reificationForContext: context [
+
+	^ context astNode
+]

--- a/src/Insight/CallGraphHistoryAction.class.st
+++ b/src/Insight/CallGraphHistoryAction.class.st
@@ -24,5 +24,5 @@ CallGraphHistoryAction >> history: aHistory [
 { #category : 'as yet unclassified' }
 CallGraphHistoryAction >> reificationForContext: context [
 
-	^ context astNode 
+	^ context astNode
 ]

--- a/src/Insight/CallHistory.class.st
+++ b/src/Insight/CallHistory.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'CallHistory',
+	#superclass : 'Object',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}

--- a/src/Insight/CallHistory.class.st
+++ b/src/Insight/CallHistory.class.st
@@ -1,7 +1,41 @@
 Class {
 	#name : 'CallHistory',
 	#superclass : 'Object',
+	#instVars : [
+		'actions'
+	],
 	#category : 'Insight-Call Graph',
 	#package : 'Insight',
 	#tag : 'Call Graph'
 }
+
+{ #category : 'api - actions' }
+CallHistory >> actions [
+	
+	^ actions
+]
+
+{ #category : 'adding' }
+CallHistory >> initialize [ 
+
+	super initialize.
+	actions := OrderedCollection new
+]
+
+{ #category : 'testing' }
+CallHistory >> isEmpty [
+	
+	^ actions isEmpty 
+]
+
+{ #category : 'adding' }
+CallHistory >> pop: method [
+
+	actions add: { 'pop' . method }
+]
+
+{ #category : 'adding' }
+CallHistory >> push: method [
+
+	actions add: { 'push' . method }
+]

--- a/src/Insight/CallHistory.class.st
+++ b/src/Insight/CallHistory.class.st
@@ -31,11 +31,11 @@ CallHistory >> isEmpty [
 { #category : 'adding' }
 CallHistory >> pop: method [
 
-	actions add: { 'pop' . method }
+	actions add: (PopAction from: method)
 ]
 
 { #category : 'adding' }
 CallHistory >> push: method [
 
-	actions add: { 'push' . method }
+	actions add: (PushAction from: method)
 ]

--- a/src/Insight/IGAction.class.st
+++ b/src/Insight/IGAction.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'IGAction',
 	#superclass : 'Object',
-	#category : 'Insight-Instrumentation Action',
+	#category : 'Insight-Actions',
 	#package : 'Insight',
-	#tag : 'Instrumentation Action'
+	#tag : 'Actions'
 }
 
 { #category : 'as yet unclassified' }

--- a/src/Insight/IGAfterMethodHook.class.st
+++ b/src/Insight/IGAfterMethodHook.class.st
@@ -5,3 +5,10 @@ Class {
 	#package : 'Insight',
 	#tag : 'Hooks'
 }
+
+{ #category : 'as yet unclassified' }
+IGAfterMethodHook >> rewriteAcceptedNode: node [
+
+	"TODO: we are duplicating this in each after hook"
+	^ action rewriteOperationsAfterNode: node
+]

--- a/src/Insight/IGAfterMethodHook.class.st
+++ b/src/Insight/IGAfterMethodHook.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'IGAfterMethodHook',
+	#superclass : 'IGMethodHook',
+	#category : 'Insight-Hooks',
+	#package : 'Insight',
+	#tag : 'Hooks'
+}

--- a/src/Insight/IGBeforeMethodHook.class.st
+++ b/src/Insight/IGBeforeMethodHook.class.st
@@ -5,3 +5,10 @@ Class {
 	#package : 'Insight',
 	#tag : 'Hooks'
 }
+
+{ #category : 'as yet unclassified' }
+IGBeforeMethodHook >> rewriteAcceptedNode: node [
+
+	"TODO: we are duplicating this in each after hook"
+	^ action rewriteOperationsBeforeNode: node
+]

--- a/src/Insight/IGBeforeMethodHook.class.st
+++ b/src/Insight/IGBeforeMethodHook.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'IGBeforeMethodHook',
+	#superclass : 'IGMethodHook',
+	#category : 'Insight-Hooks',
+	#package : 'Insight',
+	#tag : 'Hooks'
+}

--- a/src/Insight/IGCallGraphGenerator.class.st
+++ b/src/Insight/IGCallGraphGenerator.class.st
@@ -13,9 +13,6 @@ IGCallGraphGenerator class >> callGraph: aClass On: aBlock [
 	
 	history := CallHistory new.
 
-	"IGAction do: [ :context | history push: context astNode ].
-	afterAction := IGAction do: [ :context | history pop: context astNode ].
-"
 	instrumentation := IGInstrumentation new addHooks: {
 		IGBeforeMethodHook new do: (BeforeHistoryAction history: history).
 		IGAfterMethodHook new do: (AfterHistoryAction history: history)

--- a/src/Insight/IGCallGraphGenerator.class.st
+++ b/src/Insight/IGCallGraphGenerator.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'IGCallGraphGenerator',
+	#superclass : 'Object',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'as yet unclassified' }
+IGCallGraphGenerator class >> callGraph: aClass On: aBlock [
+
+	| instrumentation history |
+	
+	history := CallHistory new.
+
+	"IGAction do: [ :context | history push: context astNode ].
+	afterAction := IGAction do: [ :context | history pop: context astNode ].
+"
+	instrumentation := IGInstrumentation new addHooks: {
+		IGBeforeMethodHook new do: (BeforeHistoryAction history: history).
+		IGAfterMethodHook new do: (AfterHistoryAction history: history)
+	}; instrumentClass: aClass during: aBlock.
+
+	"^ IGCallGraph from: history"
+]

--- a/src/Insight/IGCallGraphGenerator.class.st
+++ b/src/Insight/IGCallGraphGenerator.class.st
@@ -18,5 +18,5 @@ IGCallGraphGenerator class >> callGraph: aClass On: aBlock [
 		IGAfterMethodHook new do: (AfterHistoryAction history: history)
 	}; instrumentClass: aClass during: aBlock.
 	
-	^ AllocationGraph from: history
+	^ MethodCallGraphProfiler from: history
 ]

--- a/src/Insight/IGCallGraphGenerator.class.st
+++ b/src/Insight/IGCallGraphGenerator.class.st
@@ -20,6 +20,6 @@ IGCallGraphGenerator class >> callGraph: aClass On: aBlock [
 		IGBeforeMethodHook new do: (BeforeHistoryAction history: history).
 		IGAfterMethodHook new do: (AfterHistoryAction history: history)
 	}; instrumentClass: aClass during: aBlock.
-
-	"^ IGCallGraph from: history"
+	
+	^ AllocationGraph from: history
 ]

--- a/src/Insight/IGCallGraphGeneratorTest.class.st
+++ b/src/Insight/IGCallGraphGeneratorTest.class.st
@@ -11,7 +11,7 @@ IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyBlock 
 
 	| graph |
 
-	graph := IGCallGraphGenerator callGraph: IGTest class On: [].
+	graph := IGCallGraphGenerator callGraph: IGMock On: [].
 
 	self assert: graph nodes equals: #()
 ]
@@ -21,7 +21,7 @@ IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyMethod
 
 	| graph |
 
-	graph := IGCallGraphGenerator callGraph: IGTest class On: [ IGTest new emptyMethod ].
+	graph := IGCallGraphGenerator callGraph: IGMock On: [ IGMock new emptyMethod ].
 
 	self assert: graph nodes equals: #()
 ]
@@ -31,7 +31,7 @@ IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnSimpleMetho
 
 	| graph |
 
-	graph := IGCallGraphGenerator callGraph: IGTest class On: [ IGTest new sequencialMethod ].
-1 halt.
+	graph := IGCallGraphGenerator callGraph: IGMock On: [ IGMock new messageA: 1 ].
+
 	self assert: graph nodes equals: #()
 ]

--- a/src/Insight/IGCallGraphGeneratorTest.class.st
+++ b/src/Insight/IGCallGraphGeneratorTest.class.st
@@ -13,25 +13,39 @@ IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyBlock 
 
 	graph := IGCallGraphGenerator callGraph: IGMock On: [].
 
-	self assert: graph nodes equals: #()
+	self assert: graph nodes size equals: 1 "Only the root node"
 ]
 
 { #category : 'tests' }
 IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyMethodCall [
 
-	| graph |
+	| graph initializeANode emptyMethodNode |
 
 	graph := IGCallGraphGenerator callGraph: IGMock On: [ IGMock new emptyMethod ].
+	
+	initializeANode := graph nodeForMethod: IGMock >> #initialize.
+	emptyMethodNode := graph nodeForMethod: IGMock >> #emptyMethod.
 
-	self assert: graph nodes equals: #()
+	self assert: graph nodes size equals: 3.
+	self assert: initializeANode methodCalls size equals: 0.
+	self assert: emptyMethodNode methodCalls size equals: 0
+	
 ]
 
 { #category : 'tests' }
 IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnSimpleMethodCall [
 
-	| graph |
+	| graph messageANode messageBNode |
 
-	graph := IGCallGraphGenerator callGraph: IGMock On: [ IGMock new messageA: 1 ].
+	graph := IGCallGraphGenerator
+		         callGraph: IGMock
+		         On: [ IGMock new messageA: 1 ].
+		
+	messageANode := graph nodeForMethod: IGMock >> #messageA:.
+	messageBNode := graph nodeForMethod: IGMock >> #messageB:.
 
-	self assert: graph nodes equals: #()
+	self assert: graph nodes size equals: 4.
+	self assert: messageANode methodCalls size equals: 1.
+	self assert: messageBNode methodCalls size equals: 0.
+	self assertCollection: messageANode methodCalls hasSameElements: { messageBNode }
 ]

--- a/src/Insight/IGCallGraphGeneratorTest.class.st
+++ b/src/Insight/IGCallGraphGeneratorTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : 'IGCallGraphGeneratorTest',
+	#superclass : 'TestCase',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'tests' }
+IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyBlock [
+
+	| graph |
+
+	graph := IGCallGraphGenerator callGraph: self class On: [].
+	1 halt.
+]

--- a/src/Insight/IGCallGraphGeneratorTest.class.st
+++ b/src/Insight/IGCallGraphGeneratorTest.class.st
@@ -11,6 +11,27 @@ IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyBlock 
 
 	| graph |
 
-	graph := IGCallGraphGenerator callGraph: self class On: [].
-	1 halt.
+	graph := IGCallGraphGenerator callGraph: IGTest class On: [].
+
+	self assert: graph nodes equals: #()
+]
+
+{ #category : 'tests' }
+IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnEmptyMethodCall [
+
+	| graph |
+
+	graph := IGCallGraphGenerator callGraph: IGTest class On: [ IGTest new emptyMethod ].
+
+	self assert: graph nodes equals: #()
+]
+
+{ #category : 'tests' }
+IGCallGraphGeneratorTest >> testCreatingCallGraphOfThisClassRunningAnSimpleMethodCall [
+
+	| graph |
+
+	graph := IGCallGraphGenerator callGraph: IGTest class On: [ IGTest new sequencialMethod ].
+1 halt.
+	self assert: graph nodes equals: #()
 ]

--- a/src/Insight/IGCollector.class.st
+++ b/src/Insight/IGCollector.class.st
@@ -5,9 +5,9 @@ Class {
 		'collection',
 		'collectionProperty'
 	],
-	#category : 'Insight-Instrumentation Action',
+	#category : 'Insight-Actions',
 	#package : 'Insight',
-	#tag : 'Instrumentation Action'
+	#tag : 'Actions'
 }
 
 { #category : 'enumerating' }

--- a/src/Insight/IGCounter.class.st
+++ b/src/Insight/IGCounter.class.st
@@ -6,9 +6,9 @@ Class {
 		'keyBlock',
 		'allKey'
 	],
-	#category : 'Insight-Instrumentation Action',
+	#category : 'Insight-Actions',
 	#package : 'Insight',
-	#tag : 'Instrumentation Action'
+	#tag : 'Actions'
 }
 
 { #category : 'initialization' }

--- a/src/Insight/IGDoAction.class.st
+++ b/src/Insight/IGDoAction.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Insight',
 	#tag : 'Actions'
 }
+
+{ #category : 'as yet unclassified' }
+IGDoAction >> instrumentationNodeFor: context [
+
+	1 halt.
+]

--- a/src/Insight/IGDoAction.class.st
+++ b/src/Insight/IGDoAction.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'IGDoAction',
+	#superclass : 'IGAction',
+	#category : 'Insight-Actions',
+	#package : 'Insight',
+	#tag : 'Actions'
+}

--- a/src/Insight/IGDoAction.class.st
+++ b/src/Insight/IGDoAction.class.st
@@ -7,7 +7,19 @@ Class {
 }
 
 { #category : 'as yet unclassified' }
+IGDoAction >> do: value [
+
+	self subclassResponsibility 
+]
+
+{ #category : 'as yet unclassified' }
 IGDoAction >> instrumentationNodeFor: context [
 
-	1 halt.
+	| reification |
+	reification := self reificationForContext: context.
+
+	^ OCMessageNode
+		  receiver: (OCLiteralValueNode value: self)
+		  selector: (OCSelectorNode value: #do:)
+		  arguments: { reification nodeToReify }
 ]

--- a/src/Insight/IGInstrumentation.class.st
+++ b/src/Insight/IGInstrumentation.class.st
@@ -111,6 +111,21 @@ IGInstrumentation >> rewriteAssignment: node before: beforeNodes after: afterNod
 ]
 
 { #category : 'as yet unclassified' }
+IGInstrumentation >> rewriteMethod: method before: beforeNodes after: afterNodes [ 
+
+	| methodBody newNode |
+	
+	methodBody := method body.
+	newNode := OCSequenceNode statements: (beforeNodes asArray, { methodBody }, afterNodes asArray).
+	1 halt.
+	"TODO: should we replace the current method by a new one that call have a sequence with:
+		- beforeNodes
+		- call method: sameArgs
+		- afterNodes"
+	method replaceNode: methodBody withNode: newNode
+]
+
+{ #category : 'as yet unclassified' }
 IGInstrumentation >> rewriteNode: node with: operations [
 
 	| beforeNodes afterNodes wrapStatements wrappedNode newTempNodes |
@@ -135,6 +150,13 @@ IGInstrumentation >> rewriteNode: node with: operations [
 	"Assignment case"
 	node isAssignment ifTrue: [
 		self rewriteAssignment: node before: beforeNodes after: afterNodes wrapped: wrappedNode.
+		"RETURNING"
+		^ self
+	].
+
+	"Method case"
+	node isMethod ifTrue: [
+		self rewriteMethod: node before: beforeNodes after: afterNodes.
 		"RETURNING"
 		^ self
 	].

--- a/src/Insight/IGInstrumentation.class.st
+++ b/src/Insight/IGInstrumentation.class.st
@@ -117,7 +117,6 @@ IGInstrumentation >> rewriteMethod: method before: beforeNodes after: afterNodes
 	
 	methodBody := method body.
 	newNode := OCSequenceNode statements: (beforeNodes asArray, { methodBody }, afterNodes asArray).
-	1 halt.
 	"TODO: should we replace the current method by a new one that call have a sequence with:
 		- beforeNodes
 		- call method: sameArgs

--- a/src/Insight/IGMethodHook.class.st
+++ b/src/Insight/IGMethodHook.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'IGMethodHook',
+	#superclass : 'IGHook',
+	#category : 'Insight-Hooks',
+	#package : 'Insight',
+	#tag : 'Hooks'
+}

--- a/src/Insight/IGMethodHook.class.st
+++ b/src/Insight/IGMethodHook.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Insight',
 	#tag : 'Hooks'
 }
+
+{ #category : 'actions' }
+IGMethodHook >> acceptsNode: node [
+
+	^ node isMethod
+]

--- a/src/Insight/IGMock.class.st
+++ b/src/Insight/IGMock.class.st
@@ -10,12 +10,28 @@ Class {
 	#tag : 'Tests'
 }
 
+{ #category : 'helper methods' }
+IGMock >> emptyMethod [
+]
+
 { #category : 'accessing' }
 IGMock >> initialize [ 
 
 	super initialize.
 	variable1 := 0.
 	variable2 := 0.
+]
+
+{ #category : 'helper methods' }
+IGMock >> messageA: argument [
+
+	self messageB: argument
+]
+
+{ #category : 'helper methods' }
+IGMock >> messageB: argument [
+
+	^ self yourself 
 ]
 
 { #category : 'accessing' }

--- a/src/Insight/MethodCallAction.class.st
+++ b/src/Insight/MethodCallAction.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'MethodCallAction',
+	#superclass : 'Object',
+	#instVars : [
+		'method'
+	],
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'instance creation' }
+MethodCallAction class >> from: method [
+
+	^ self new method: method
+]
+
+{ #category : 'accessing' }
+MethodCallAction >> method [
+	
+	^ method
+]
+
+{ #category : 'accessing' }
+MethodCallAction >> method: aMethod [
+
+	method := aMethod
+]

--- a/src/Insight/MethodCallGraphProfiler.extension.st
+++ b/src/Insight/MethodCallGraphProfiler.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : 'MethodCallGraphProfiler' }
+
+{ #category : '*Insight' }
+MethodCallGraphProfiler class >> from: callHistory [
+
+	| graph |
+
+	graph := self new.
+
+	callHistory actions do: [ :action |
+			action isPush
+				ifTrue: [ graph enteringMethod: action method ]
+				ifFalse: [ graph exitingMethod ] ].
+
+	^ graph
+]

--- a/src/Insight/PopAction.class.st
+++ b/src/Insight/PopAction.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'PopAction',
+	#superclass : 'MethodCallAction',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'testing' }
+PopAction >> isPush [
+
+	^ false
+]

--- a/src/Insight/PushAction.class.st
+++ b/src/Insight/PushAction.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'PushAction',
+	#superclass : 'MethodCallAction',
+	#category : 'Insight-Call Graph',
+	#package : 'Insight',
+	#tag : 'Call Graph'
+}
+
+{ #category : 'testing' }
+PushAction >> isPush [
+
+	^ true
+]


### PR DESCRIPTION
### Implementing Call Graph Profiler

This PR implements a straightforward first version of the Call graph profiler using Insight.

I added a method-level hook to rewrite entire methods instead of sub nodes ( statements, expressions, etc ).

I implemented a new Tag with the Call Graph Profiler logic, along with tests to validate its usage. Here is an example:

```st
	graph := IGCallGraphGenerator callGraph: IGMock On: [ IGMock new messageA: 1 ].
```

In this first try, we are instrumenting an entire class, but we can extend the api to support a list of instrument methods.

**Note 1**: Observe that I created and am extending a new Action class (`DoAction`).
**Note 2**: I am rewriting the method by wrapping the previous body with all the hooks before nodes, followed by the original code, followed by the hooks after nodes. This means that we are not executing the after nodes in case there is a return.

To fix this, we have to wrap the original body with an ensure.