### PR TITLE
Implement the core API design

### DIFF
--- a/src/BaselineOfInsight/BaselineOfInsight.class.st
+++ b/src/BaselineOfInsight/BaselineOfInsight.class.st
@@ -16,6 +16,6 @@ BaselineOfInsight >> baseline: spec [
 	spec package: 'Insight'
 		with: [ spec requires: #( 'MethodCallGraph' ) ].
 
-	spec package: 'IGCodeCov'
+	spec package: 'IG-CodeCov'
 		with: [ spec requires: #( 'Insight' ) ]
 ]

--- a/src/BaselineOfInsight/BaselineOfInsight.class.st
+++ b/src/BaselineOfInsight/BaselineOfInsight.class.st
@@ -9,8 +9,13 @@ Class {
 BaselineOfInsight >> baseline: spec [
 
 	<baseline>
-	
-	spec baseline: 'MethodCallGraph' with: [ spec repository: 'github://jordanmontt/MethodCallGraph:main' ].
-	
-	spec package: 'Insight' with: [ spec requires: #( 'MethodCallGraph' ) ]
+	spec baseline: 'MethodCallGraph'
+		with: [
+		spec repository: 'github://jordanmontt/MethodCallGraph:main' ].
+
+	spec package: 'Insight'
+		with: [ spec requires: #( 'MethodCallGraph' ) ].
+
+	spec package: 'IGCodeCov'
+		with: [ spec requires: #( 'Insight' ) ]
 ]

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -14,6 +14,18 @@ Class {
 	#tag : 'IG-CodeCoverage'
 }
 
+{ #category : 'private' }
+IGCodeCoverageProfiler >> buildResultFor: aCollectionOfMethods [
+	"Populate an IGCoverageResult from the profiling"
+
+	| result |
+
+	result := IGCoverageResult new.
+	aCollectionOfMethods do: [ :eachMethod |
+		result addMethodCoverage: (self methodCoverageFor: eachMethod) ].
+	coverageResult := result
+]
+
 { #category : 'api' }
 IGCodeCoverageProfiler >> classesToInstrument: aCollection [
 	" Sugar for getting and instrumenting the methods from the classes."
@@ -55,6 +67,20 @@ IGCodeCoverageProfiler >> initialize [
 	coverageResult := IGCoverageResult new.
 ]
 
+{ #category : 'private' }
+IGCodeCoverageProfiler >> methodCoverageFor: aMethod [
+	"Build a IGMethodCoverage struct from the counter values"
+
+	| executedStatements |
+
+	executedStatements := IdentityDictionary new.
+	aMethod ast statements do: [ :eachNode |
+			executedStatements at: eachNode
+				put: (statementCounter countAt: eachNode)
+			].
+	^IGMethodCoverage method: aMethod executedStatements: executedStatements 
+]
+
 { #category : 'api' }
 IGCodeCoverageProfiler >> methodsToInstrument: aCollection [
 	"Register every method found in the collection for profiling.
@@ -64,4 +90,21 @@ IGCodeCoverageProfiler >> methodsToInstrument: aCollection [
 		each isCompiledMethod
 			ifTrue: [ methods add: each ]
 			ifFalse: [ self methodsToInstrument: each ] ]
+]
+
+{ #category : 'api' }
+IGCodeCoverageProfiler >> profileOn: aBlock [
+
+	| instrumentation statementHook uniqueMethods |
+
+	statementCounter := IGCounter new countKeyBy: #astNode.
+	statementHook := IGAfterStatementHook new do: statementCounter.
+
+	instrumentation := IGInstrumentation new addHook: statementHook.
+
+	uniqueMethods := methods asSet asArray.
+	instrumentation instrumentMethods: uniqueMethods
+		during: aBlock.
+
+	self buildResultFor: uniqueMethods
 ]

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -13,3 +13,55 @@ Class {
 	#package : 'IG-CodeCov',
 	#tag : 'IG-CodeCoverage'
 }
+
+{ #category : 'api' }
+IGCodeCoverageProfiler >> classesToInstrument: aCollection [
+	" Sugar for getting and instrumenting the methods from the classes."
+
+	| flattenClasses |
+
+	flattenClasses := self flattenClassesFrom: aCollection.
+	self methodsToInstrument: (flattenClasses flatCollect: #definedMethods)
+]
+
+{ #category : 'accessing' }
+IGCodeCoverageProfiler >> coverageResult [
+
+	^coverageResult
+]
+
+{ #category : 'private' }
+IGCodeCoverageProfiler >> flattenClassesFrom: aCollection [
+
+	| flattenedCollection |
+
+	flattenedCollection := OrderedCollection new.
+
+	aCollection do: [ :each |
+			each isClass ifTrue: [ flattenedCollection add: each ]
+				ifFalse: [
+						flattenedCollection
+							addAll: (self flattenClassesFrom: each)
+						]
+			].
+	^flattenedCollection
+]
+
+{ #category : 'initialization' }
+IGCodeCoverageProfiler >> initialize [
+
+	super initialize.
+	methods := OrderedCollection new.
+	coverageResult := IGCoverageResult new.
+]
+
+{ #category : 'api' }
+IGCodeCoverageProfiler >> methodsToInstrument: aCollection [
+	"Register every method found in the collection for profiling.
+	The collection may be nested"
+
+	aCollection do: [ :each|
+		each isCompiledMethod
+			ifTrue: [ methods add: each ]
+			ifFalse: [ self methodsToInstrument: each ] ]
+]

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -81,6 +81,12 @@ IGCodeCoverageProfiler >> methodCoverageFor: aMethod [
 	^IGMethodCoverage method: aMethod executedStatements: executedStatements 
 ]
 
+{ #category : 'private - accessing' }
+IGCodeCoverageProfiler >> methods [
+
+	^methods
+]
+
 { #category : 'api' }
 IGCodeCoverageProfiler >> methodsToInstrument: aCollection [
 	"Register every method found in the collection for profiling.

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -1,0 +1,15 @@
+"
+Statement level code coverage profiler that can instrument methods and clasess, execute a block of code, and produce a structured coverage report.
+"
+Class {
+	#name : 'IGCodeCoverageProfiler',
+	#superclass : 'Object',
+	#instVars : [
+		'methods',
+		'coverageResult',
+		'statementCounter'
+	],
+	#category : 'IG-CodeCov-IG-CodeCoverage',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverage'
+}

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -1,5 +1,5 @@
 "
-Statement level code coverage profiler that can instrument methods and clasess, execute a block of code, and produce a structured coverage report.
+Statement level code coverage profiler that can instrument methods and classes, execute a block of code, and produce a structured coverage report.
 "
 Class {
 	#name : 'IGCodeCoverageProfiler',

--- a/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
@@ -54,7 +54,7 @@ IGCodeCoverageProfilerTest >> testClassesToInstrumentAcceptsNestedCollections [
 ]
 
 { #category : 'tests - classes' }
-IGCodeCoverageProfilerTest >> testClassestoInstrumentCoversAllDefinedMethod [
+IGCodeCoverageProfilerTest >> testClassesToInstrumentCoversAllDefinedMethods [
 
 	| profiler |
 

--- a/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
@@ -1,0 +1,212 @@
+Class {
+	#name : 'IGCodeCoverageProfilerTest',
+	#superclass : 'TestCase',
+	#category : 'IG-CodeCov-IG-CodeCoverageTest',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverageTest'
+}
+
+{ #category : 'tests - classes' }
+IGCodeCoverageProfilerTest >> testClassExecutedMethodsAreCovered [
+
+	| profiler result |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler classesToInstrument: { IGCoverageMock }.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result := profiler coverageResult.
+
+	self assertCollection:
+		(result methodCoverageFor: IGCoverageMock >> #oneStatement ) executedStatements asArray
+		equals: { 1 }.
+	self assertCollection:
+		(result methodCoverageFor: IGCoverageMock >> #initialize ) executedStatements asArray
+		equals: { 1 }
+]
+
+{ #category : 'tests - classes' }
+IGCodeCoverageProfilerTest >> testClassNeverCalledMethodIsUncovered [
+
+	| profiler result |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler classesToInstrument: { IGCoverageMock }.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result := profiler coverageResult.
+
+	self assertCollection:
+		(result methodCoverageFor: IGCoverageMock >> #twoStatements ) executedStatements asArray
+		equals: { 0. 0 }
+]
+
+{ #category : 'tests - classes' }
+IGCodeCoverageProfilerTest >> testClassesToInstrumentAcceptsNestedCollections [
+
+	| profiler method |
+
+	method := IGCoverageMock >> #emptyMethod.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler classesToInstrument: { { IGCoverageMock } }.
+
+	self assertCollection: profiler methods asArray
+		includesAny: { method }
+]
+
+{ #category : 'tests - classes' }
+IGCodeCoverageProfilerTest >> testClassestoInstrumentCoversAllDefinedMethod [
+
+	| profiler |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler classesToInstrument: { IGCoverageMock }.
+
+	self assertCollection: profiler methods asArray
+		equals: IGCoverageMock definedMethods
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testCoverageResultBeforeProfilingIsEmpty [
+
+	| profiler |
+
+	profiler := IGCodeCoverageProfiler new.
+	self assert: profiler coverageResult methodCoverages isEmpty
+]
+
+{ #category : 'tests - methods' }
+IGCodeCoverageProfilerTest >> testExecutedMethodIsCovered [
+
+	| profiler result method |
+
+	method := IGCoverageMock >> #oneStatement.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { method }.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result := profiler coverageResult.
+
+	self assertCollection:
+		(result methodCoverageFor: method) executedStatements asArray
+		equals: { 1 }
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testInstrumentationIsRestoredAfterProfiling [
+
+	| profiler method before after |
+
+	method := IGCoverageMock>>#emptyMethod.
+	before := IGCoverageMock methodDict at: #emptyMethod.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { method }.
+	profiler profileOn: [ IGCoverageMock new emptyMethod ].
+
+	after := IGCoverageMock methodDict at: #emptyMethod.
+	self assert: before identicalTo: after
+]
+
+{ #category : 'tests - methods' }
+IGCodeCoverageProfilerTest >> testMethodUncoveredWhenNotExecuted [
+
+	| profiler result method |
+
+	method := IGCoverageMock >> #twoStatements.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { method }.
+	profiler profileOn: [ "Nothing" ].
+	result := profiler coverageResult.
+
+	self assertCollection:
+		(result methodCoverageFor: method) executedStatements asArray
+		equals: { 0. 0 }
+]
+
+{ #category : 'tests - methods' }
+IGCodeCoverageProfilerTest >> testMethodsToInstrumentAcceptsNestedCollections [
+
+	| profiler |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: {
+			{ IGCoverageMock >> #oneStatement }.
+			{ IGCoverageMock >> #twoStatements } }.
+
+	self assertCollection: profiler methods asArray
+		equals: {
+				(IGCoverageMock >> #oneStatement).
+				(IGCoverageMock >> #twoStatements) }
+]
+
+{ #category : 'tests - methods' }
+IGCodeCoverageProfilerTest >> testMethodsToInstrumentSeveralCallsCanBeCombined [
+
+	| profiler |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { IGCoverageMock >> #oneStatement }.
+	profiler methodsToInstrument: { IGCoverageMock >> #twoStatements }.
+
+	self assertCollection: profiler methods asArray
+		equals: {
+				(IGCoverageMock >> #oneStatement).
+				(IGCoverageMock >> #twoStatements) }
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testProfileOnWithNoInstrumentationIsNoOp [
+
+	| profiler executed |
+
+	executed := false.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler profileOn: [ executed := true ].
+
+	self assert: executed.
+	self assert: profiler coverageResult methodCoverages isEmpty
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testRepeatedProfilingDifferentBlock [
+	"profileOn: should be idempotent"
+
+	| profiler result1 result2 method |
+
+	method := IGCoverageMock >> #oneStatement.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { method }.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result1 := profiler coverageResult.
+	profiler profileOn: [ "Nothing" ].
+	result2 := profiler coverageResult.
+
+	self assertCollection:
+		(result1 methodCoverageFor: method) executedStatements asArray
+		equals: { 1 }.
+	self assertCollection:
+		(result2 methodCoverageFor: method) executedStatements asArray
+		equals: { 0 }
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testRepeatedProfilingSameBlock [
+	"profileOn: should be idempotent"
+
+	| profiler result1 result2 method |
+
+	method := IGCoverageMock >> #oneStatement.
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: { method }.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result1 := profiler coverageResult.
+	profiler profileOn: [ IGCoverageMock new oneStatement ].
+	result2 := profiler coverageResult.
+
+	self assertCollection: (result1 methodCoverageFor: method) executedStatements
+		equals: (result2 methodCoverageFor: method) executedStatements
+]

--- a/src/IG-CodeCov/IGCoverageMock.class.st
+++ b/src/IG-CodeCov/IGCoverageMock.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'IGCoverageMock',
+	#superclass : 'Object',
+	#category : 'IG-CodeCov-IG-CodeCoverageTest',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverageTest'
+}
+
+{ #category : 'dummy methods' }
+IGCoverageMock >> emptyMethod [
+
+	
+]
+
+{ #category : 'initialization' }
+IGCoverageMock >> initialize [
+
+	super initialize
+]
+
+{ #category : 'dummy methods' }
+IGCoverageMock >> oneStatement [
+
+	^42
+]
+
+{ #category : 'dummy methods' }
+IGCoverageMock >> twoStatements [
+
+	| x |
+
+	x := 1.
+	^x + 1
+]

--- a/src/IG-CodeCov/IGCoverageResult.class.st
+++ b/src/IG-CodeCov/IGCoverageResult.class.st
@@ -1,0 +1,46 @@
+"
+Coverage object that can expose the percentages of coverage of methods and has well as how many of them where fully covered.
+"
+Class {
+	#name : 'IGCoverageResult',
+	#superclass : 'Object',
+	#instVars : [
+		'methodCoverages'
+	],
+	#category : 'IG-CodeCov-IG-CodeCoverage',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverage'
+}
+
+{ #category : 'adding' }
+IGCoverageResult >> addMethodCoverage: anIGMethodCoverage [
+
+	methodCoverages at: anIGMethodCoverage method put: anIGMethodCoverage
+]
+
+{ #category : 'initialization' }
+IGCoverageResult >> initialize [
+
+	super initialize.
+	methodCoverages := IdentityDictionary new
+]
+
+{ #category : 'accessing' }
+IGCoverageResult >> methodCoverageFor: aMethod [
+	"Raise an error if the method isn't present"
+
+	^ methodCoverages at: aMethod ifAbsent: [
+		self error: ('Method {1} is not present.' format: { aMethod printString }) ]
+]
+
+{ #category : 'accessing' }
+IGCoverageResult >> methodCoverages [
+
+	^ methodCoverages values
+]
+
+{ #category : 'accessing' }
+IGCoverageResult >> numberOfMethods [
+
+	^methodCoverages size
+]

--- a/src/IG-CodeCov/IGCoverageResult.class.st
+++ b/src/IG-CodeCov/IGCoverageResult.class.st
@@ -1,5 +1,5 @@
 "
-Coverage object that can expose the percentages of coverage of methods and has well as how many of them where fully covered.
+Coverage object that exposes method coverage percentages as well as how many of them were fully covered.
 "
 Class {
 	#name : 'IGCoverageResult',

--- a/src/IG-CodeCov/IGCoverageResultTest.class.st
+++ b/src/IG-CodeCov/IGCoverageResultTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'IGCoverageResultTest',
+	#superclass : 'TestCase',
+	#category : 'IG-CodeCov-IG-CodeCoverageTest',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverageTest'
+}
+
+{ #category : 'tests' }
+IGCoverageResultTest >> testMethodCoverageForRaiseWhenMethodNotInScope [
+
+	self should: [ IGCoverageResult new methodCoverageFor: #someMethod ] raise: Error
+]

--- a/src/IG-CodeCov/IGMethodCoverage.class.st
+++ b/src/IG-CodeCov/IGMethodCoverage.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : 'IGMethodCoverage',
+	#superclass : 'Object',
+	#instVars : [
+		'method',
+		'executedStatements'
+	],
+	#category : 'IG-CodeCov-IG-CodeCoverage',
+	#package : 'IG-CodeCov',
+	#tag : 'IG-CodeCoverage'
+}
+
+{ #category : 'instance creation' }
+IGMethodCoverage class >> method: aMethod executedStatements: aDictionary [
+
+	^self new
+		 method: aMethod; executedStatements: aDictionary; yourself
+]
+
+{ #category : 'accessing' }
+IGMethodCoverage >> executedStatements [
+
+	^executedStatements
+]
+
+{ #category : 'accessing' }
+IGMethodCoverage >> executedStatements: aDictionnary [
+
+	executedStatements := aDictionnary
+]
+
+{ #category : 'querying' }
+IGMethodCoverage >> executionCountFor: aNode [
+
+	^executedStatements at: aNode
+		 ifAbsent: [ 0 ]
+]
+
+{ #category : 'initialization' }
+IGMethodCoverage >> initialize [
+
+	super initialize.
+	executedStatements := IdentityDictionary new
+]
+
+{ #category : 'accessing' }
+IGMethodCoverage >> method [
+
+	^method
+]
+
+{ #category : 'accessing' }
+IGMethodCoverage >> method: aMethod [
+
+	method := aMethod
+]

--- a/src/IG-CodeCov/IGMethodCoverage.class.st
+++ b/src/IG-CodeCov/IGMethodCoverage.class.st
@@ -24,9 +24,9 @@ IGMethodCoverage >> executedStatements [
 ]
 
 { #category : 'accessing' }
-IGMethodCoverage >> executedStatements: aDictionnary [
+IGMethodCoverage >> executedStatements: aDictionary [
 
-	executedStatements := aDictionnary
+	executedStatements := aDictionary
 ]
 
 { #category : 'querying' }

--- a/src/IG-CodeCov/ManifestIGCodeCov.class.st
+++ b/src/IG-CodeCov/ManifestIGCodeCov.class.st
@@ -1,0 +1,24 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestIGCodeCov',
+	#superclass : 'PackageManifest',
+	#category : 'IG-CodeCov-Manifest',
+	#package : 'IG-CodeCov',
+	#tag : 'Manifest'
+}
+
+{ #category : 'code-critics' }
+ManifestIGCodeCov class >> ruleJustSendsSuperRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#IGCoverageMock #initialize #false)) #'2026-04-21T18:17:36.767241+02:00') )
+]
+
+{ #category : 'code-critics' }
+ManifestIGCodeCov class >> ruleNobodyShouldSendMethodDictV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#IGCodeCoverageProfilerTest #testInstrumentationIsRestoredAfterProfiling #false)) #'2026-04-21T17:54:29.852699+02:00') )
+]

--- a/src/IG-CodeCov/package.st
+++ b/src/IG-CodeCov/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'IG-CodeCov' }

--- a/src/Insight/IGInstrumentation.class.st
+++ b/src/Insight/IGInstrumentation.class.st
@@ -101,6 +101,16 @@ IGInstrumentation >> instrumentMethod: method during: blockToEval [
 ]
 
 { #category : 'as yet unclassified' }
+IGInstrumentation >> instrumentMethods: methodCollection during: blockToEval [
+
+	[
+		methodCollection do: [ :method | self instrumentMethod: method ].
+		blockToEval value
+		] ensure: [
+		methodCollection do: [ :method | self uninstrumentMethod: method ] ]
+]
+
+{ #category : 'as yet unclassified' }
 IGInstrumentation >> rewriteAssignment: node before: beforeNodes after: afterNodes wrapped: wrappedNode [
 
 	| newNodes |


### PR DESCRIPTION
- **implement a very basic coverage object and coverage API**
- **implement the profiler "hooking API"**
- **implement the core of the profiling logic**
- **write test for the profiling using the basic API of `IGCoverageResult`**

## Summary
Implement a profiler `IGCodeCoverageProfiler` that profile classes and methods.

The coverage result object is left very basic: contains a collection of `IGMethodCoverage` structure.
No real API, just some getters for the `MethodCoverage` instance of a specific method.

The test manipulate the structure instances directly for now.

Closes #41
