### PR TITLE
Introduce `coverageFor:` as method percentage querying

### DIFF
--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -55,10 +55,12 @@ IGCodeCoverageProfiler >> getExectutedStatementsFor: aMethod [
 	| executedStatements |
 
 	executedStatements := IdentityDictionary new.
-	aMethod ast allStatements do: [ :eachNode |
-			executedStatements at: eachNode
-				put: (statementCounter countAt: eachNode)
-			].
+	"Reject variable nodes, as they are not statements and thus not relevant for coverage."
+	(aMethod ast allStatements reject: [ :eachStatement| eachStatement isVariable ])
+		do: [ :eachNode |
+				executedStatements at: eachNode
+										 put: (statementCounter countAt: eachNode)
+			 ].
 	^executedStatements
 ]
 

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -55,7 +55,7 @@ IGCodeCoverageProfiler >> getExectutedStatementsFor: aMethod [
 	| executedStatements |
 
 	executedStatements := IdentityDictionary new.
-	aMethod ast statements do: [ :eachNode |
+	aMethod ast allStatements do: [ :eachNode |
 			executedStatements at: eachNode
 				put: (statementCounter countAt: eachNode)
 			].

--- a/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfiler.class.st
@@ -55,12 +55,11 @@ IGCodeCoverageProfiler >> getExectutedStatementsFor: aMethod [
 	| executedStatements |
 
 	executedStatements := IdentityDictionary new.
-	"Reject variable nodes, as they are not statements and thus not relevant for coverage."
-	(aMethod ast allStatements reject: [ :eachStatement| eachStatement isVariable ])
-		do: [ :eachNode |
-				executedStatements at: eachNode
-										 put: (statementCounter countAt: eachNode)
-			 ].
+	"Reject temporaries, as they are not statements and thus not relevant for coverage."
+	aMethod ast allStatementsWithoutTemporaries do: [ :eachNode |
+			executedStatements at: eachNode
+				put: (statementCounter countAt: eachNode)
+			].
 	^executedStatements
 ]
 

--- a/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
@@ -9,8 +9,8 @@ Class {
 { #category : 'helper' }
 IGCodeCoverageProfilerTest >> assertRecord: aMethodRecord equals: expected [
 
-	self assertCollection: aMethodRecord executedStatements asArray
-		equals: expected
+	self assertCollection: aMethodRecord executedStatements values
+		hasSameElements: expected
 ]
 
 { #category : 'helper' }
@@ -69,6 +69,21 @@ IGCodeCoverageProfilerTest >> testExecutedMethodIsCovered [
 
 	self assertRecord: methodCoverage
 		equals: { 1 }
+]
+
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testExecutionCountForRaiseWhenStatementIsNotPartOfMethod [
+
+	| methodCoverage method statement |
+
+	method := IGCoverageMock >> #oneStatement.
+	statement := (IGCoverageMock >> #twoStatements) ast statements first.
+	methodCoverage := self profileMethod: method
+		                  on: [ IGCoverageMock new twoStatements ].
+
+	self should: [ methodCoverage executionCountFor: statement ]
+
+		raise: Error
 ]
 
 { #category : 'tests - profiling' }

--- a/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
+++ b/src/IG-CodeCov/IGCodeCoverageProfilerTest.class.st
@@ -86,6 +86,22 @@ IGCodeCoverageProfilerTest >> testExecutionCountForRaiseWhenStatementIsNotPartOf
 		raise: Error
 ]
 
+{ #category : 'tests' }
+IGCodeCoverageProfilerTest >> testExecutionCountIs2ForAStatementCalledTwice [
+
+	| methodCoverage statement |
+
+	statement := (IGCoverageMock >> #oneStatement) ast statements first.
+	methodCoverage := (self profileClass: IGCoverageMock
+		                   on: [
+				                   IGCoverageMock new
+					                   callSubMethod; oneStatement
+				                   ]) recordFor: IGCoverageMock >> #oneStatement.
+
+	self assert: (methodCoverage executionCountFor: statement)
+		equals: 2
+]
+
 { #category : 'tests - profiling' }
 IGCodeCoverageProfilerTest >> testMethodUncoveredWhenNotExecuted [
 

--- a/src/IG-CodeCov/IGCoverageMock.class.st
+++ b/src/IG-CodeCov/IGCoverageMock.class.st
@@ -14,7 +14,7 @@ IGCoverageMock >> callSubMethod [
 ]
 
 { #category : 'dummy methods' }
-IGCoverageMock >> conditionalMethodAAA: aBoolean [
+IGCoverageMock >> conditionalMethod: aBoolean [
 
 	^aBoolean ifTrue: [ 67 ]
 		 ifFalse: [ 42 ]

--- a/src/IG-CodeCov/IGCoverageResult.class.st
+++ b/src/IG-CodeCov/IGCoverageResult.class.st
@@ -19,6 +19,16 @@ IGCoverageResult >> addRecord: anIGMethodCoverageRecord [
 		put: anIGMethodCoverageRecord
 ]
 
+{ #category : 'querying' }
+IGCoverageResult >> coverageFor: aMethod [
+
+	| methodRecord |
+
+	methodRecord := self recordFor: aMethod.
+	^(methodRecord numberOfExecutedStatements
+	  / methodRecord numberOfStatements * 100) asFloat
+]
+
 { #category : 'initialization' }
 IGCoverageResult >> initialize [
 
@@ -34,14 +44,8 @@ IGCoverageResult >> isEmpty [
 	^methodRecordDictionary isEmpty
 ]
 
-{ #category : 'accessing' }
-IGCoverageResult >> methodRecordDictionary [
-
-    ^ methodRecordDictionary
-]
-
 { #category : 'querying' }
-IGCoverageResult >> numberOfRecordedMethods [
+IGCoverageResult >> numberOfRecordedMethod [
 
     ^ methodRecordDictionary size
 ]
@@ -55,4 +59,10 @@ IGCoverageResult >> recordFor: aMethod [
 				 self error:
 					 ('Method {1} is not present.' format: { aMethod printString })
 				 ]
+]
+
+{ #category : 'accessing' }
+IGCoverageResult >> recordedMethodCollection [
+
+    ^ methodRecordDictionary
 ]

--- a/src/IG-CodeCov/IGCoverageResultTest.class.st
+++ b/src/IG-CodeCov/IGCoverageResultTest.class.st
@@ -34,17 +34,6 @@ IGCoverageResultTest >> testFullyExecutedMethodCoverageIs100 [
 
 	| method |
 
-	method := IGCoverageMock >> #oneStatement.
-	self assertCoverageForMethod: method
-		running: [ IGCoverageMock new oneStatement ]
-		equals: 100 asFloat
-]
-
-{ #category : 'tests – failing' }
-IGCoverageResultTest >> testFullyExecutedMethodCoverageIs100Failing [
-
-	| method |
-
 	method := IGCoverageMock >> #twoStatements.
 	self assertCoverageForMethod: method
 		running: [ IGCoverageMock new twoStatements ]

--- a/src/IG-CodeCov/IGCoverageResultTest.class.st
+++ b/src/IG-CodeCov/IGCoverageResultTest.class.st
@@ -6,9 +6,95 @@ Class {
 	#tag : 'IG-CodeCoverageTest'
 }
 
-{ #category : 'tests' }
-IGCoverageResultTest >> testMethodCoverageForRaiseWhenMethodNotInScope [
+{ #category : 'helper' }
+IGCoverageResultTest >> assertCoverageForMethod: aMethod running: aBlock equals: expectedCoverage [
 
-	self should: [ IGCoverageResult new methodCoverageFor: #someMethod ]
+	| coverageResult |
+
+	coverageResult := self profileInstrumenting: { aMethod }
+		                  running: aBlock.
+	self assert: (coverageResult coverageFor: aMethod)
+		equals: expectedCoverage
+]
+
+{ #category : 'helper' }
+IGCoverageResultTest >> profileInstrumenting: aMethodCollection running: aBlock [
+
+	| profiler |
+
+	profiler := IGCodeCoverageProfiler new.
+	profiler methodsToInstrument: aMethodCollection.
+	profiler profileOn: aBlock.
+
+	^profiler coverageResult
+]
+
+{ #category : 'tests – coverage' }
+IGCoverageResultTest >> testFullyExecutedMethodCoverageIs100 [
+
+	| method |
+
+	method := IGCoverageMock >> #oneStatement.
+	self assertCoverageForMethod: method
+		running: [ IGCoverageMock new oneStatement ]
+		equals: 100 asFloat
+]
+
+{ #category : 'tests – failing' }
+IGCoverageResultTest >> testFullyExecutedMethodCoverageIs100Failing [
+
+	| method |
+
+	method := IGCoverageMock >> #twoStatements.
+	self assertCoverageForMethod: method
+		running: [ IGCoverageMock new twoStatements ]
+		equals: 100 asFloat
+]
+
+{ #category : 'tests – coverage' }
+IGCoverageResultTest >> testNotExecutedMethodCoverageIs0 [
+
+	| method |
+
+	method := IGCoverageMock >> #twoStatements.
+	self assertCoverageForMethod: method
+		running: [ "Nothing" ]
+		equals: 0 asFloat
+]
+
+{ #category : 'tests – coverage' }
+IGCoverageResultTest >> testPartiallyExectutedMethodCoverageIsBetween0And100 [
+	"IGCoverageMock >> #conditionalMethod: has 3 statements
+	Calling with true execute 2 of them, so coverage is 66%."
+
+	| method |
+
+	method := IGCoverageMock >> #conditionalMethod:.
+	self assertCoverageForMethod: method
+		running: [ IGCoverageMock new conditionalMethod: true ]
+		equals: (2 / 3 * 100) asFloat
+]
+
+{ #category : 'tests – exception' }
+IGCoverageResultTest >> testRecordForRaiseWhenMethodNotInScope [
+
+	self should: [ IGCoverageResult new recordFor: #someMethod ]
 		raise: Error
+]
+
+{ #category : 'tests – coverage' }
+IGCoverageResultTest >> testRepeatedExecutionDoesNotInflateCoverage [
+
+	| method |
+
+	method := IGCoverageMock >> #conditionalMethod:.
+	self
+		assertCoverageForMethod: method
+		running: [
+				| mock |
+
+				mock := IGCoverageMock new.
+				5 timesRepeat: [ mock conditionalMethod: false ]
+				]
+		equals: (2 / 3 * 100) asFloat
 ]

--- a/src/IG-CodeCov/IGMethodCoverageRecord.class.st
+++ b/src/IG-CodeCov/IGMethodCoverageRecord.class.st
@@ -53,3 +53,16 @@ IGMethodCoverageRecord >> method: aMethod [
 
 	method := aMethod
 ]
+
+{ #category : 'querying' }
+IGMethodCoverageRecord >> numberOfExecutedStatements [
+
+	^(executedStatements values select: [ :eachValue | eachValue > 0 ])
+		 size
+]
+
+{ #category : 'querying' }
+IGMethodCoverageRecord >> numberOfStatements [
+
+	^executedStatements size
+]

--- a/src/Insight/OCArrayNode.extension.st
+++ b/src/Insight/OCArrayNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'OCArrayNode' }
+
+{ #category : '*Insight' }
+OCArrayNode >> allStatementsWithoutTemporaries [
+
+	^self allStatements
+]

--- a/src/Insight/OCBlockNode.extension.st
+++ b/src/Insight/OCBlockNode.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'OCBlockNode' }
 
 { #category : '*Insight' }
+OCBlockNode >> allStatementsWithoutTemporaries [
+	"ignoring temp variable definition."
+
+	^OrderedCollection new
+		 addAll: super allStatements; yourself
+]
+
+{ #category : '*Insight' }
 OCBlockNode >> flattened [
 
 	^ self copy body: (body flattened); yourself

--- a/src/Insight/OCMethodNode.extension.st
+++ b/src/Insight/OCMethodNode.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'OCMethodNode' }
 
 { #category : '*Insight' }
+OCMethodNode >> allStatementsWithoutTemporaries [
+	"return the statements ignoring variable definition."
+
+	^OrderedCollection new addAll: super allStatements; yourself
+]
+
+{ #category : '*Insight' }
 OCMethodNode >> flattened [
 	
 	^ self copy body: (self body flattened); yourself

--- a/src/Insight/OCProgramNode.extension.st
+++ b/src/Insight/OCProgramNode.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'OCProgramNode' }
 
 { #category : '*Insight' }
+OCProgramNode >> allStatementsWithoutTemporaries [
+
+	^self allStatements
+]
+
+{ #category : '*Insight' }
 OCProgramNode >> childAtPath: aPath [
 
     "Return the AST node following aPath from myself.

--- a/src/Insight/OCSequenceNode.extension.st
+++ b/src/Insight/OCSequenceNode.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'OCSequenceNode' }
 
 { #category : '*Insight' }
+OCSequenceNode >> allStatementsWithoutTemporaries [
+
+	^self allStatements
+]
+
+{ #category : '*Insight' }
 OCSequenceNode >> flattened [
 
 	| newStatements |


### PR DESCRIPTION
## Summary

Introduce `coverageFor:` a method on `coverageResult` to query for the percentqge of execution of a method.

## Unexpected behaviour
The Pharo `allStatements` method on asts of method account for variable declaration as statement, while `Insight` doesn't.

Fixes #42 