### PR TITLE
fix the instrumentation temporay shadowing problem

### DIFF
--- a/src/Insight/IGInstrumentation.class.st
+++ b/src/Insight/IGInstrumentation.class.st
@@ -58,6 +58,12 @@ IGInstrumentation >> generateInstrumentedMethod: method [
 	^ method methodClass compiler ast: instrumentedAST; doSemanticAnalysis; compile
 ]
 
+{ #category : 'private' }
+IGInstrumentation >> generateTemporaryNameWithPrefix: aPrefix [
+
+	^ aPrefix , UUID new asString36
+]
+
 { #category : 'initialization' }
 IGInstrumentation >> initialize [ 
 	
@@ -123,13 +129,14 @@ IGInstrumentation >> rewriteAssignment: node before: beforeNodes after: afterNod
 { #category : 'as yet unclassified' }
 IGInstrumentation >> rewriteLastBlockStatementNode: node before: beforeNodes after: afterNodes wrapped: wrappedNode [
 
-	| assigmentNode newReturnNode |
+	| assigmentNode newReturnNode tempName |
 
-	node parent addTemporaryNamed: 'blockReturnVal'.
-	assigmentNode := OCAssignmentNode variable: (OCVariableNode named: 'blockReturnVal')
+	tempName := self generateTemporaryNameWithPrefix: 'igBlockReturnVal'.
+	node parent addTemporaryNamed: tempName.
+	assigmentNode := OCAssignmentNode variable: (OCVariableNode named: tempName)
 		                 value: wrappedNode.
 
-	newReturnNode := OCVariableNode named: 'blockReturnVal'.
+	newReturnNode := OCVariableNode named: tempName.
 
 	^ node parent replaceNode: node
 		  withNodes:
@@ -210,17 +217,20 @@ IGInstrumentation >> rewriteNode: node with: operations [
 { #category : 'as yet unclassified' }
 IGInstrumentation >> rewriteReturnNode: node before: beforeNodes after: afterNodes wrapped: wrappedNode [
 
-	| assigmentNode newReturnNode returnValueNode |
-	
+	| assigmentNode newReturnNode returnValueNode tempName |
+
+	tempName := self generateTemporaryNameWithPrefix: 'igReturnVal'.
 	returnValueNode := wrappedNode value.
-	node parent addTemporaryNamed: 'returnVal'.
-	assigmentNode := OCAssignmentNode
-		variable: (OCVariableNode named: 'returnVal') value: returnValueNode.
+	node parent addTemporaryNamed: tempName.
 
-	newReturnNode := OCReturnNode value: (OCVariableNode named: 'returnVal').
+	assigmentNode := OCAssignmentNode variable: (OCVariableNode named: tempName)
+		                 value: returnValueNode.
 
-	^ node parent replaceNode: node withNodes:
-		beforeNodes asArray, { assigmentNode }, afterNodes asArray, { newReturnNode }
+	newReturnNode := OCReturnNode value: (OCVariableNode named: tempName).
+
+	^ node parent replaceNode: node
+		  withNodes:
+		  beforeNodes asArray , { assigmentNode } , afterNodes asArray , { newReturnNode }
 ]
 
 { #category : 'as yet unclassified' }

--- a/src/Insight/IGInstrumentation.class.st
+++ b/src/Insight/IGInstrumentation.class.st
@@ -131,7 +131,7 @@ IGInstrumentation >> rewriteLastBlockStatementNode: node before: beforeNodes aft
 
 	| assigmentNode newReturnNode tempName |
 
-	tempName := self generateTemporaryNameWithPrefix: 'igBlockReturnVal'.
+	tempName := self generateTemporaryNameWithPrefix: 'blockReturnVal'.
 	node parent addTemporaryNamed: tempName.
 	assigmentNode := OCAssignmentNode variable: (OCVariableNode named: tempName)
 		                 value: wrappedNode.
@@ -219,7 +219,7 @@ IGInstrumentation >> rewriteReturnNode: node before: beforeNodes after: afterNod
 
 	| assigmentNode newReturnNode returnValueNode tempName |
 
-	tempName := self generateTemporaryNameWithPrefix: 'igReturnVal'.
+	tempName := self generateTemporaryNameWithPrefix: 'returnVal'.
 	returnValueNode := wrappedNode value.
 	node parent addTemporaryNamed: tempName.
 

--- a/src/Insight/IGTest.class.st
+++ b/src/Insight/IGTest.class.st
@@ -66,6 +66,18 @@ IGTest >> methodWithBlockImplicitReturn [
 ]
 
 { #category : 'helper methods' }
+IGTest >> nestedBlockShadowing [
+
+	| blockReturnVal anotherBlockReturnVal |
+
+	anotherBlockReturnVal := [
+		                         blockReturnVal := [ 69 - 67 ] value.
+		                         40 ] value.
+
+	^ blockReturnVal + anotherBlockReturnVal
+]
+
+{ #category : 'helper methods' }
 IGTest >> returnMethod [
 
 	^ 42
@@ -86,6 +98,24 @@ IGTest >> slowFactorial: n [
 
 	n < 2 ifTrue: [ ^1 ].
 	^n * (self slowFactorial: n - 1)
+]
+
+{ #category : 'method tests' }
+IGTest >> testAfterStatementHookDoesnotShadow [
+
+	| afterHook counter methodToInstrument result |
+
+	counter := IGCounter new.
+	afterHook := IGAfterStatementHook new do: counter.
+	methodToInstrument := IGTest >> #nestedBlockShadowing.
+
+	self instrumenting: methodToInstrument
+		with: { afterHook }
+		running: [ result := self nestedBlockShadowing ]
+		assert: [ :method |
+				self assert: result
+					equals: 42.
+				self assert: counter count > 0 ]
 ]
 
 { #category : 'method tests' }

--- a/src/Insight/ManifestInsight.class.st
+++ b/src/Insight/ManifestInsight.class.st
@@ -20,14 +20,14 @@ ManifestInsight class >> ruleAssignmentInIfTrueRuleV1FalsePositive [
 ManifestInsight class >> ruleExtraBlockRuleV1FalsePositive [
 
 	<ignoreForCoverage>
-	^ #(#(#(#RGMethodDefinition #(#IGTest #methodWithBlockImplicitReturn #false)) #'2026-05-06T11:11:43.905312+02:00') )
+	^ #(#(#(#RGMethodDefinition #(#IGTest #methodWithBlockImplicitReturn #false)) #'2026-05-06T11:11:43.905312+02:00') #(#(#RGMethodDefinition #(#IGTest #nestedBlockShadowing #false)) #'2026-05-06T14:51:38.467629+02:00') )
 ]
 
 { #category : 'code-critics' }
 ManifestInsight class >> ruleTempsReadBeforeWrittenRuleV1FalsePositive [
 
 	<ignoreForCoverage>
-	^ #(#(#(#RGMethodDefinition #(#IGTest #testRecursiveMethodAccumulatesCount #false)) #'2026-04-17T14:22:16.945895+02:00') )
+	^ #(#(#(#RGMethodDefinition #(#IGTest #testRecursiveMethodAccumulatesCount #false)) #'2026-04-17T14:22:16.945895+02:00') #(#(#RGMethodDefinition #(#IGTest #nestedBlockShadowing #false)) #'2026-05-06T14:52:11.619812+02:00') #(#(#RGClassDefinition #(#IGTest)) #'2026-05-06T15:00:26.924271+02:00') )
 ]
 
 { #category : 'code-critics' }


### PR DESCRIPTION
## Summary
This PR introduce a private helper to IGIntrumentation that generate an UUID for the name of the temporaries used, ensuring no shadowing of exisitng variable.

I have added a prefix to them so that it is easier to find them inside the bytecode and/or know what the node are referencing to.

Closes #53
