### PR TITLE
add flattenedNodes message implemnation to some OCNode classes

### DIFF
--- a/src/Insight/IGASTTest.class.st
+++ b/src/Insight/IGASTTest.class.st
@@ -33,6 +33,28 @@ IGASTTest >> testAssignmentNodeToList1 [
 ]
 
 { #category : 'tests' }
+IGASTTest >> testFlattenedNodesArrayPreserveOrder [
+
+	| arrayNode firstAssignment chainedAssignmentInner chainedAssignmentOuter lastAssignment flattenedAray |
+
+	arrayNode := OCParser parseExpression: '{ a := 1. b := a := a * 3. c := b - 2 }'.
+
+	firstAssignment := OCParser parseExpression: 'a := 1'.
+	chainedAssignmentInner := OCParser parseExpression: 'a := a * 3'.
+	chainedAssignmentOuter := OCParser parseExpression: 'b := a'.
+	lastAssignment := OCParser parseExpression: 'c := b - 2'.
+	flattenedAray := OCParser parseExpression: '{ a. b. c }'.
+
+	self assertCollection: arrayNode flattenedNodes
+		equals: {
+				firstAssignment.
+				chainedAssignmentInner.
+				chainedAssignmentOuter.
+				lastAssignment.
+				flattenedAray }
+]
+
+{ #category : 'tests' }
 IGASTTest >> testFlattenedNodesArrayWithInnerAssignement [
 
 	| arrayNode innerAssignement flattenedArray |

--- a/src/Insight/IGASTTest.class.st
+++ b/src/Insight/IGASTTest.class.st
@@ -33,6 +33,21 @@ IGASTTest >> testAssignmentNodeToList1 [
 ]
 
 { #category : 'tests' }
+IGASTTest >> testFlattenedNodesArrayWithInnerAssignement [
+
+	| arrayNode innerAssignement flattenedArray |
+
+	arrayNode := OCParser parseExpression: '{ a := 1. b. c }'.
+	innerAssignement := OCParser parseExpression: 'a := 1'.
+	flattenedArray := OCParser parseExpression: '{a. b. c}'.
+
+	self assertCollection: arrayNode flattenedNodes
+		equals: {
+				innerAssignement.
+				flattenedArray }
+]
+
+{ #category : 'tests' }
 IGASTTest >> testFlattenedNodesAssignment1 [
 
 	| assignment1 |
@@ -99,4 +114,58 @@ IGASTTest >> testFlattenedNodesAssignmentInReceiver [
 	flattenedNode1 := OCParser parseExpression: 'a msg: 7'.
 	
 	self assertCollection: assignment1 flattenedNodes equals: { innerNode . flattenedNode1 }
+]
+
+{ #category : 'tests' }
+IGASTTest >> testFlattenedNodesBlockWithInnerAssignement [
+
+	| blockNode flattenedBlock |
+
+	blockNode := OCParser parseExpression: '[ a := 1. b + (c := 2) ]'.
+	flattenedBlock := OCParser parseExpression: '[ a := 1. c := 2. b + c ]'.
+
+	self assertCollection: blockNode flattenedNodes
+		equals: { flattenedBlock }
+]
+
+{ #category : 'tests' }
+IGASTTest >> testFlattenedNodesCascadeWithInnerAssignement [
+
+	| cascadeNode innerAssignement flattenedCascade |
+
+	cascadeNode := OCParser parseExpression: 'obj msg1; msg2: (x := 5); msg3'.
+	innerAssignement := OCParser parseExpression: 'x := 5'.
+	flattenedCascade := OCParser parseExpression: 'obj msg1; msg2: x; msg3'.
+
+	self assertCollection: cascadeNode flattenedNodes
+		equals: {
+				innerAssignement.
+				flattenedCascade }
+]
+
+{ #category : 'tests' }
+IGASTTest >> testFlattenedNodesMessageWithoutAssignement [
+
+	| messageNode flattenedMessage |
+
+	messageNode := OCParser parseExpression: 'a msg1: b plus: c'.
+	flattenedMessage := OCParser parseExpression: 'a msg1: b plus: c'.
+
+	self assertCollection: messageNode flattenedNodes
+		equals: { flattenedMessage }
+]
+
+{ #category : 'tests' }
+IGASTTest >> testFlattenedNodesReturnWithInnerAssignement [
+
+	| returnNode innerAssignement flattenedReturn |
+
+	returnNode := OCParser parseExpression: '^ (x := 7)'.
+	innerAssignement := OCParser parseExpression: 'x := 7'.
+	flattenedReturn := OCParser parseExpression: '^ x'.
+
+	self assertCollection: returnNode flattenedNodes
+		equals: {
+				innerAssignement.
+				flattenedReturn }
 ]

--- a/src/Insight/OCArrayNode.extension.st
+++ b/src/Insight/OCArrayNode.extension.st
@@ -5,3 +5,22 @@ OCArrayNode >> allStatementsWithoutTemporaries [
 
 	^self allStatements
 ]
+
+{ #category : '*Insight' }
+OCArrayNode >> flattenedNodes [
+
+	| newSelf flattenedChildren |
+
+	flattenedChildren := OrderedCollection new.
+	newSelf := self copy.
+
+	newSelf statements: (self statements collect: [ :stmt |
+				 | flattenedStmt |
+
+				 flattenedStmt := stmt flattenedNodes.
+				 flattenedChildren addAll: flattenedStmt.
+				 stmt isAssignment ifTrue: [ stmt variable copy ]
+					 ifFalse: [ flattenedStmt first ] ]).
+
+	^ (flattenedChildren reject: #isLeafNode) asArray , { newSelf }
+]

--- a/src/Insight/OCCascadeNode.extension.st
+++ b/src/Insight/OCCascadeNode.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : 'OCCascadeNode' }
+
+{ #category : '*Insight' }
+OCCascadeNode >> flattenedNodes [
+
+	| newSelf flattenedChildren |
+
+	flattenedChildren := OrderedCollection new.
+	newSelf := self copy.
+
+	newSelf messages: (self messages collect: [ :message |
+				 | flattenedMessage |
+
+				 flattenedMessage := message flattenedNodes.
+				 flattenedChildren addAll: flattenedMessage.
+				 flattenedMessage last ]) asOrderedCollection.
+
+	^ (flattenedChildren reject: #isLeafNode) asArray , { newSelf }
+]

--- a/src/Insight/OCLiteralArrayNode.extension.st
+++ b/src/Insight/OCLiteralArrayNode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'OCLiteralArrayNode' }
+
+{ #category : '*Insight' }
+OCLiteralArrayNode >> flattenedNodes [
+
+	^ { self copy }
+]

--- a/src/Insight/OCLiteralArrayNode.extension.st
+++ b/src/Insight/OCLiteralArrayNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'OCLiteralArrayNode' }
-
-{ #category : '*Insight' }
-OCLiteralArrayNode >> flattenedNodes [
-
-	^ { self copy }
-]

--- a/src/Insight/OCLiteralValueNode.extension.st
+++ b/src/Insight/OCLiteralValueNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'OCLiteralValueNode' }
-
-{ #category : '*Insight' }
-OCLiteralValueNode >> flattenedNodes [
-	
-	^ { self copy }
-]

--- a/src/Insight/OCMethodNode.extension.st
+++ b/src/Insight/OCMethodNode.extension.st
@@ -12,3 +12,9 @@ OCMethodNode >> flattened [
 	
 	^ self copy body: (self body flattened); yourself
 ]
+
+{ #category : '*Insight' }
+OCMethodNode >> flattenedNodes [
+
+	^ self flattened
+]

--- a/src/Insight/OCProgramNode.extension.st
+++ b/src/Insight/OCProgramNode.extension.st
@@ -19,6 +19,12 @@ OCProgramNode >> childAtPath: aPath [
 ]
 
 { #category : '*Insight' }
+OCProgramNode >> flattenedNodes [
+
+	^ { self copy }
+]
+
+{ #category : '*Insight' }
 OCProgramNode >> isLastBlockStatement [
 
 	parent ifNil: [ ^ false ].

--- a/src/Insight/OCSequenceNode.extension.st
+++ b/src/Insight/OCSequenceNode.extension.st
@@ -15,3 +15,9 @@ OCSequenceNode >> flattened [
 
 	^ self copy statements: newStatements; yourself
 ]
+
+{ #category : '*Insight' }
+OCSequenceNode >> flattenedNodes [
+
+	^ self flattened
+]

--- a/src/Insight/OCVariableNode.extension.st
+++ b/src/Insight/OCVariableNode.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'OCVariableNode' }
-
-{ #category : '*Insight' }
-OCVariableNode >> flattenedNodes [
-	
-	^ { self copy }
-]


### PR DESCRIPTION
## Summary
This PR introduce some method implementation for the message `flattenedNodes` for the cascade and array syntax.

These where needed to profile the `Micordown-Tests` package.

## Profiling results:
```smalltalk
['Microdown-Tests' asPackage testSuite run] timeToRun.
"0:00:00:01.267"
"0:00:00:01.183"
"0:00:00:01.346"
"0:00:00:01.281"
"0:00:00:01.504"
"1326 ran, 1326 passed, 3 skipped, 0 expected failures, 0 failures, 0 errors, 0 passed unexpected"

res := nil.
IGCodeCoverageProfiler new
   classesToInstrument: 'Microdown' asPackage definedClasses;
   profileOn: [
      res := ['Microdown-Tests' asPackage testSuite run] timeToRun ].
res.
"0:00:00:01.591"
"0:00:00:01.379"
"0:00:00:01.478"
"0:00:00:01.374"
"0:00:00:01.3"
"1326 ran, 1324 passed, 3 skipped, 0 expected failures, 0 failures, 2 errors, 0 passed unexpected"
"(MicPharoImageResourceReferenceTest>>#testMicrodownImport MicPharoImageResourceReferenceTest>>#testIcon)"
```

Closes #54
